### PR TITLE
add JSON support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2510,6 +2510,15 @@
         "rollup-pluginutils": "^2.3.3"
       }
     },
+    "rollup-plugin-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "^2.3.1"
+      }
+    },
     "rollup-plugin-node-resolve": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "rimraf": "^2.6.3",
     "rollup": "^1.2.3",
     "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^4.0.1",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import rollupPluginNodeResolve from 'rollup-plugin-node-resolve';
 import rollupPluginCommonjs from 'rollup-plugin-commonjs';
 import {terser as rollupPluginTerser} from 'rollup-plugin-terser';
 import rollupPluginReplace from 'rollup-plugin-replace';
+import rollupPluginJson from 'rollup-plugin-json';
 
 export interface InstallOptions {
   destLoc: string;
@@ -109,6 +110,11 @@ export async function install(
         // whether to prefer built-in modules (e.g. `fs`, `path`) or local ones with the same names
         preferBuiltins: false, // Default: true
       }),
+      !isStrict &&
+        rollupPluginJson({
+          preferConst: true,
+          indent: '  ',
+        }),
       !isStrict &&
         rollupPluginCommonjs({
           extensions: ['.js', '.cjs'], // Default: [ '.js' ]


### PR DESCRIPTION
Adds support for dependencies that import a JSON file as a module. This isn't supported yet in ES2019 syntax, but it's common enough in Node.js & NPM ecosystem that we need to support it.