### PR TITLE
Add rollup-plugin-replace to replace NODE_ENV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2518,6 +2518,17 @@
         "resolve": "^1.10.0"
       }
     },
+    "rollup-plugin-replace": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.1.0.tgz",
+      "integrity": "sha512-SxrAIgpH/B5/W4SeULgreOemxcpEgKs2gcD42zXw50bhqGWmcnlXneVInQpAqzA/cIly4bJrOpeelmB9p4YXSQ==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.1",
+        "minimatch": "^3.0.2",
+        "rollup-pluginutils": "^2.0.1"
+      }
+    },
     "rollup-plugin-terser": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@pika/plugin-simple-bin": "^0.3.12",
     "@pika/plugin-ts-standard-pkg": "^0.3.12",
     "prettier": "^1.16.4",
+    "rollup-plugin-replace": "^2.1.0",
     "typescript": "^3.3.3333"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import * as rollup from 'rollup';
 import rollupPluginNodeResolve from 'rollup-plugin-node-resolve';
 import rollupPluginCommonjs from 'rollup-plugin-commonjs';
 import { terser as rollupPluginTerser } from "rollup-plugin-terser";
+import rollupPluginReplace from 'rollup-plugin-replace';
 
 export interface InstallOptions {
   destLoc: string;
@@ -79,6 +80,9 @@ export async function install(arrayOfDeps: string[], {isCleanInstall, destLoc, i
   const inputOptions = {
     input: depObject,
     plugins: [
+      rollupPluginReplace({
+        'process.env.NODE_ENV': isOptimized ? '"production"' : '"development"'
+      }),
       rollupPluginNodeResolve({
         module: true, // Default: true
         jsnext: false,  // Default: false


### PR DESCRIPTION
As packages like to use `process.env.NODE_ENV` to check whether
it's used it production or development, `rollup-plugin-replace`
will replace `process.env.NODE_ENV` with `"development"` or
`"production"` depending of the `--optimize` flag.