### PR TITLE
Finalize: Install dependencies by path

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
     "trailingComma": "all",
     "bracketSpacing": false,
     "printWidth": 100,
-    "parser": "flow"
+    "parser": "typescript"
   }

--- a/README.md
+++ b/README.md
@@ -82,16 +82,21 @@ More testing is needed, but at this early stage we feel confident extrapolating 
 
 > *Note: All package.json options are scoped under the `"@pika/web"` property.*
 
-* `"webDependencies"`: You can define an optional whitelist of "webDependencies" in your `package.json` manifest. This is useful if your entire "dependencies" object is too large or contains unrelated, server-only packages that may break @pika/web.
+
+* `"webDependencies"`: You can define an optional whitelist of "webDependencies" in your `package.json` manifest. This is useful if your entire "dependencies" object is too large, or if you'd like to install dependencies by file path.
 
 ```js
-  "dependencies": {
-    "htm": "^1.0.0",
-    "preact": "^8.0.0",
-    /* A mix of other server and frontend dependencies */
+  "dependencies": { "htm": "^1.0.0", "preact": "^8.0.0", /* ... */ },
+  "@pika/web": {
+    "webDependencies": [
+      "htm",
+      "preact",
+      "preact/hooks", // A package within a package
+      "unistore/full/preact.es.js" // An ESM file within a package
+    ]
   },
-  "@pika/web": {"webDependencies": ["htm", "preact"]},
 ```
+
 
 ### CLI Options
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ More testing is needed, but at this early stage we feel confident extrapolating 
 
 > *Note: All package.json options are scoped under the `"@pika/web"` property.*
 
-
 * `"webDependencies"`: You can define an optional whitelist of "webDependencies" in your `package.json` manifest. This is useful if your entire "dependencies" object is too large, or if you'd like to install dependencies by file path.
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,13 @@ function resolveWebDependency(dep: string): string {
   );
 }
 
-function transformWebModuleFilename(depName: string): string {
-  return depName.replace(/\//g, '--').replace(/\.js$/, '');
+/**
+ * Formats the @pika/web dependency name from a "webDependencies" input value:
+ * 1. Replace all `/` URL/path seperators with "--"
+ * 2. Remove any ".js" extension (will be added automatically by Rollup)
+ */
+function getWebDependencyName(dep: string): string {
+  return dep.replace(/\//g, '--').replace(/\.js$/, '');
 }
 
 export async function install(
@@ -107,7 +112,7 @@ export async function install(
   const depObject = {};
   for (const dep of arrayOfDeps) {
     try {
-      const depName = transformWebModuleFilename(dep);
+      const depName = getWebDependencyName(dep);
       const depLoc = resolveWebDependency(dep);
       depObject[depName] = depLoc;
     } catch (err) {
@@ -116,7 +121,6 @@ export async function install(
       if (err.hint) {
         console.log(err.hint);
       }
-      // If you're working off of an explicit whitelist: exit. Otherwise, continue.
       if (!skipFailures) {
         return false;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,18 @@ export interface InstallOptions {
   isOptimized?: boolean;
 }
 
+interface ESModuleResolutionResult {
+  found: boolean;
+  path?: string;
+}
+interface ESModuleDescriptorExplicit {
+  type: 'es_module' | 'directory';
+  path: 'string';
+}
+type ESModuleDescriptor
+  = string
+  | ESModuleDescriptorExplicit;
+
 const cwd = process.cwd();
 let spinner = ora(chalk.bold(`@pika/web`) + ` installing...`);
 
@@ -39,11 +51,60 @@ function logError(msg) {
   spinner.fail();
 }
 
+function moduleDescriptorToWebModuleName(esModule: ESModuleDescriptor): string {
+  if (typeof esModule === 'string') {
+    return transformWebModuleFilename(esModule);
+  }
+  return transformWebModuleFilename(esModule.path);
+}
+
 function transformWebModuleFilename(depName:string):string {
   return depName.replace('/', '--');
 }
 
-export async function install(arrayOfDeps: string[], {isCleanInstall, destLoc, isWhitelist, isStrict, isOptimized}: InstallOptions) {
+class ErrorWithHint extends Error {
+  constructor(message: string, public readonly hint: string) {
+    super(message);
+    // see: typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html
+    Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain
+  }
+}
+
+function locateEsModule(esModule: ESModuleDescriptor, toleratePackagesLackingModules: boolean): ESModuleResolutionResult {
+  if (typeof esModule === 'string') {
+    return locateEsModuleWithinDirectory(esModule, toleratePackagesLackingModules);
+  }
+  if (esModule.type === 'directory') {
+    return locateEsModuleWithinDirectory(esModule.path, toleratePackagesLackingModules);
+  }
+  return {
+    found: true,
+    path: path.join(cwd, 'node_modules', esModule.path),
+  };
+}
+
+function locateEsModuleWithinDirectory(directory: string, toleratePackagesLackingModules: boolean): ESModuleResolutionResult {
+  const moduleDirectory = path.join(cwd, 'node_modules', directory);
+  if (!fs.existsSync(moduleDirectory)) {
+    throw new Error(`dependency "${directory}" not found in your node_modules/ directory. Did you run npm install?`);
+  }
+  const manifestPath = path.join(moduleDirectory, 'package.json');
+  const manifest = require(manifestPath);
+  if (!manifest.module) {
+    if (!toleratePackagesLackingModules) {
+      throw new ErrorWithHint(
+        `dependency "${directory}" has no ES "module" entrypoint.`,
+        '\n' + chalk.italic(`Tip: Find modern, web-ready packages at ${chalk.underline('https://pikapkg.com/packages')}`) + '\n');
+    }
+    return { found: false };
+  }
+  return {
+    found: true,
+    path: path.join(moduleDirectory, manifest.module),
+  };
+}
+
+export async function install(arrayOfDeps: ESModuleDescriptor[], {isCleanInstall, destLoc, isWhitelist, isStrict, isOptimized}: InstallOptions) {
   if (arrayOfDeps.length === 0) {
     logError('no dependencies found.');
     return;
@@ -59,22 +120,19 @@ export async function install(arrayOfDeps: string[], {isCleanInstall, destLoc, i
 
   const depObject = {};
   for (const dep of arrayOfDeps) {
-    const depLoc = path.join(cwd, 'node_modules', dep);
-    if (!fs.existsSync(depLoc)) {
-        logError(`dependency "${dep}" not found in your node_modules/ directory. Did you run npm install?`);
+    try {
+      const resolutionResult = locateEsModule(dep, !isWhitelist);
+      if (!resolutionResult.found) {
+        continue;
+      }
+      depObject[moduleDescriptorToWebModuleName(dep)] = resolutionResult.path;
+    } catch(err) {
+      logError(err.message);
+      if (err instanceof ErrorWithHint) {
+        console.log(err.hint);
+      }
       return;
     }
-    const depManifestLoc = path.join(cwd, 'node_modules', dep, 'package.json');
-    const depManifest = require(depManifestLoc);
-    if (!depManifest.module) {
-      if (isWhitelist) {
-        logError(`dependency "${dep}" has no ES "module" entrypoint.`);
-        console.log('\n' + chalk.italic(`Tip: Find modern, web-ready packages at ${chalk.underline('https://pikapkg.com/packages')}`) + '\n');
-        return false;
-      }
-      continue;
-    }
-    depObject[transformWebModuleFilename(dep)] = path.join(depLoc, depManifest.module);
   }
 
   const inputOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,18 +52,18 @@ class ErrorWithHint extends Error {
  * field instead of the CJS "main" field.
  */
 function resolveWebDependency(dep: string): string {
-  const lazyDependencyPath = path.join(cwd, 'node_modules', dep);
+  const nodeModulesLoc = path.join(cwd, 'node_modules', dep);
   let dependencyStats: fs.Stats;
   try {
-    dependencyStats = fs.statSync(lazyDependencyPath);
+    dependencyStats = fs.statSync(nodeModulesLoc);
   } catch (err) {
     throw new Error(`"${dep}" not found in your node_modules directory. Did you run npm install?`);
   }
   if (dependencyStats.isFile()) {
-    return lazyDependencyPath;
+    return nodeModulesLoc;
   }
   if (dependencyStats.isDirectory()) {
-    const dependencyManifestLoc = path.join(cwd, 'node_modules', dep, 'package.json');
+    const dependencyManifestLoc = path.join(nodeModulesLoc, 'package.json');
     const manifest = require(dependencyManifestLoc);
     if (!manifest.module) {
       throw new ErrorWithHint(
@@ -75,11 +75,11 @@ function resolveWebDependency(dep: string): string {
         ),
       );
     }
-    return path.join(cwd, 'node_modules', dep, manifest.module);
+    return path.join(nodeModulesLoc, manifest.module);
   }
 
   throw new Error(
-    `Error loading "${dep}" at "${lazyDependencyPath}". (MODE=${dependencyStats.mode}) `,
+    `Error loading "${dep}" at "${nodeModulesLoc}". (MODE=${dependencyStats.mode}) `,
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,22 +14,20 @@ import rollupPluginReplace from 'rollup-plugin-replace';
 export interface InstallOptions {
   destLoc: string;
   isCleanInstall?: boolean;
-  isWhitelist?: boolean;
+  isExplicitDeps?: boolean;
   isStrict?: boolean;
   isOptimized?: boolean;
 }
 
+type DependencyType
+  = 'package'
+  | 'module';
+
 interface ESModuleResolutionResult {
-  found: boolean;
+  isPackageLackingModule?: boolean;
   path?: string;
+  depNameRefersTo: DependencyType;
 }
-interface ESModuleDescriptorExplicit {
-  type: 'es_module' | 'directory';
-  path: 'string';
-}
-type ESModuleDescriptor
-  = string
-  | ESModuleDescriptorExplicit;
 
 const cwd = process.cwd();
 let spinner = ora(chalk.bold(`@pika/web`) + ` installing...`);
@@ -51,15 +49,20 @@ function logError(msg) {
   spinner.fail();
 }
 
-function moduleDescriptorToWebModuleName(esModule: ESModuleDescriptor): string {
-  if (typeof esModule === 'string') {
-    return transformWebModuleFilename(esModule);
+function dependencyDescriptorToWebModuleFileName(dependencyDescriptor: string, dependencyType: DependencyType): string {
+  let dependencyName;
+  if (dependencyType === 'package') {
+    dependencyName = dependencyDescriptor;
+  } else if (dependencyType === 'module') {
+    dependencyName = dependencyDescriptor.replace(/\.js$/, '');
+  } else {
+    throw new Error(`Unsupported dependency type, "${dependencyType}".`);
   }
-  return transformWebModuleFilename(esModule.path);
+  return sanitizeReservedFilesystemCharacters(dependencyName);
 }
 
-function transformWebModuleFilename(depName:string):string {
-  return depName.replace('/', '--');
+function sanitizeReservedFilesystemCharacters(path: string): string {
+  return path.replace('/', '--');
 }
 
 class ErrorWithHint extends Error {
@@ -70,69 +73,74 @@ class ErrorWithHint extends Error {
   }
 }
 
-function locateEsModule(esModule: ESModuleDescriptor, toleratePackagesLackingModules: boolean): ESModuleResolutionResult {
-  if (typeof esModule === 'string') {
-    return locateEsModuleWithinDirectory(esModule, toleratePackagesLackingModules);
+function locateEsModule(dependencyDescriptor: string): ESModuleResolutionResult {
+  const dependencyPath = path.join(cwd, 'node_modules', dependencyDescriptor);
+  if (!fs.existsSync(dependencyPath)) {
+    throw new Error(`dependency "${dependencyDescriptor}" not found in your node_modules/ directory. Did you run npm install?`);
   }
-  if (esModule.type === 'directory') {
-    return locateEsModuleWithinDirectory(esModule.path, toleratePackagesLackingModules);
+  const dependencyStats = fs.statSync(dependencyPath);
+  if (dependencyStats.isDirectory()) {
+    return locateEsModuleWithinDirectory(dependencyPath);
   }
-  return {
-    found: true,
-    path: path.join(cwd, 'node_modules', esModule.path),
-  };
+  if (dependencyStats.isFile()) {
+    return {
+      depNameRefersTo: 'module',
+      path: dependencyPath,
+    };
+  }
+  throw new Error(`Dependency "${dependencyDescriptor}"'s path, "${dependencyPath}" refers to neither a directory nor a regular file.`);
 }
 
-function locateEsModuleWithinDirectory(directory: string, toleratePackagesLackingModules: boolean): ESModuleResolutionResult {
-  const moduleDirectory = path.join(cwd, 'node_modules', directory);
-  if (!fs.existsSync(moduleDirectory)) {
-    throw new Error(`dependency "${directory}" not found in your node_modules/ directory. Did you run npm install?`);
-  }
-  const manifestPath = path.join(moduleDirectory, 'package.json');
+function locateEsModuleWithinDirectory(packageDirectory: string): ESModuleResolutionResult {
+  const manifestPath = path.join(packageDirectory, 'package.json');
   const manifest = require(manifestPath);
   if (!manifest.module) {
-    if (!toleratePackagesLackingModules) {
-      throw new ErrorWithHint(
-        `dependency "${directory}" has no ES "module" entrypoint.`,
-        '\n' + chalk.italic(`Tip: Find modern, web-ready packages at ${chalk.underline('https://pikapkg.com/packages')}`) + '\n');
-    }
-    return { found: false };
+    return {
+      depNameRefersTo: 'package',
+      isPackageLackingModule: true,
+    };
   }
   return {
-    found: true,
-    path: path.join(moduleDirectory, manifest.module),
+    depNameRefersTo: 'package',
+    path: path.join(packageDirectory, manifest.module),
   };
 }
 
-export async function install(arrayOfDeps: ESModuleDescriptor[], {isCleanInstall, destLoc, isWhitelist, isStrict, isOptimized}: InstallOptions) {
-  if (arrayOfDeps.length === 0) {
-    logError('no dependencies found.');
-    return;
-  }
-  if (!fs.existsSync(path.join(cwd, 'node_modules'))) {
-    logError('no node_modules/ directory exists. Run "npm install" in your project before running @pika/web.');
-    return;
-  }
-
-  if (isCleanInstall) {
-    rimraf.sync(destLoc);
-  }
-
+export async function install(arrayOfDeps: string[], {isCleanInstall, destLoc, isExplicitDeps, isStrict, isOptimized}: InstallOptions) {
   const depObject = {};
-  for (const dep of arrayOfDeps) {
-    try {
-      const resolutionResult = locateEsModule(dep, !isWhitelist);
-      if (!resolutionResult.found) {
+  try {
+    if (arrayOfDeps.length === 0) {
+      throw new Error('no dependencies found.');
+    }
+    if (!fs.existsSync(path.join(cwd, 'node_modules'))) {
+      throw new Error('no node_modules/ directory exists. Run "npm install" in your project before running @pika/web.');
+    }
+
+    if (isCleanInstall) {
+      rimraf.sync(destLoc);
+    }
+
+    for (const dep of arrayOfDeps) {
+      const resolutionResult = locateEsModule(dep);
+      if (resolutionResult.isPackageLackingModule) {
+        if (isExplicitDeps) {
+          throw new ErrorWithHint(
+            `dependency "${dep}"'s package.json has no ES "module" entrypoint.`,
+            '\n' + chalk.italic(`Tip: Find modern, web-ready packages at ${chalk.underline('https://pikapkg.com/packages')}`) + '\n'
+            );
+        }
+        // user didn't explicitly specify which packages they care about, so we settle for best-effort
         continue;
       }
-      depObject[moduleDescriptorToWebModuleName(dep)] = resolutionResult.path;
-    } catch(err) {
-      logError(err.message);
-      if (err instanceof ErrorWithHint) {
-        console.log(err.hint);
-      }
-      return;
+      depObject[dependencyDescriptorToWebModuleFileName(dep, resolutionResult.depNameRefersTo)] = resolutionResult.path;
     }
+
+  } catch(err) {
+    logError(err.message);
+    if (err instanceof ErrorWithHint) {
+      console.log(err.hint);
+    }
+    return;
   }
 
   const inputOptions = {
@@ -179,11 +187,11 @@ export async function cli(args: string[]) {
   }
 
   const cwdManifest = require(path.join(cwd, 'package.json'));
-  const isWhitelist = !!cwdManifest && !!cwdManifest['@pika/web'] && !!cwdManifest['@pika/web'].webDependencies;
-  const arrayOfDeps = isWhitelist ? cwdManifest['@pika/web'].webDependencies : Object.keys(cwdManifest.dependencies || {});
+  const isExplicitDeps = !!cwdManifest && !!cwdManifest['@pika/web'] && !!cwdManifest['@pika/web'].webDependencies;
+  const arrayOfDeps = isExplicitDeps ? cwdManifest['@pika/web'].webDependencies : Object.keys(cwdManifest.dependencies || {});
   spinner.start();
   const startTime = Date.now();
-  const result = await install(arrayOfDeps, {isCleanInstall: clean, destLoc, isWhitelist, isStrict: strict, isOptimized: optimize});
+  const result = await install(arrayOfDeps, {isCleanInstall: clean, destLoc, isExplicitDeps, isStrict: strict, isOptimized: optimize});
   if (result) {
     spinner.succeed(chalk.green.bold(`@pika/web`) + ` installed web-native dependencies. ` + chalk.dim(`[${((Date.now() - startTime) / 1000).toFixed(2)}s]`));
   }


### PR DESCRIPTION
Closes #20, Includes work by @Birch-san in #21

All I really did here was scope #21 down to just focus on this feature. There were some other concepts introduced that I'd love to explore further but for now they are decoupled from this PR.

Tested as working on the following config: 

```
  "@pika/web": {
    "webDependencies": [
      "@pika/fetch",
      "preact",
      "preact/hooks",
      "unistore/full/preact.es.js",
      "epoch-timeago",
      "htm",
      "popper.js"
    ]
  },
```

Result:

<img width="356" alt="Screen Shot 2019-03-09 at 2 41 25 PM" src="https://user-images.githubusercontent.com/622227/54078222-713fe680-4279-11e9-81e0-6be489d2925c.png">
