### PR TITLE
Allow specifying of command line options from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ More testing is needed, but at this early stage we feel confident extrapolating 
   },
 ```
 
+#### Additional `package.json` Options
+
+The [CLI options](#cli-options) below can also be added directly to the `@pika/web` object in `package.json` allowing you to set default values that can be overridden using the command line.
+
+```json
+{
+  "@pika/web": {
+    "dest": "htdocs"
+  }
+}
+```
+
 
 ### CLI Options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,22 +192,22 @@ function packageCfg() {
 }
 
 export async function cli(args: string[]) {
-  const {help, optimize = false, strict = false, clean = false, dest = 'web_modules'} = 
-    // overwrite package.json arguments with CLI arguments
-    Object.assign(packageCfg(), yargs(args));
+  const cwdManifest = packageCfg();
+  const {help = false, optimize = false, strict = false, clean = false, dest = 'web_modules'} = {
+    ...yargs(args),
+    ...(cwdManifest['@pika/web'] || {})
+  };
   const destLoc = path.join(cwd, dest);
 
   if (help) {
     showHelp();
     process.exit(0);
   }
-
-  const cwdManifest = require(path.join(cwd, 'package.json'));
   const doesWhitelistExist = !!(
-    cwdManifest['@pika/web'] && cwdManifest['@pika/web'].webDependencies
+    cwdManifest && cwdManifest.webDependencies
   );
   const arrayOfDeps = doesWhitelistExist
-    ? cwdManifest['@pika/web'].webDependencies
+    ? cwdManifest.webDependencies
     : Object.keys(cwdManifest.dependencies || {});
   spinner.start();
   const startTime = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,8 +180,21 @@ export async function install(
   return true;
 }
 
+/**
+ * Returns CLI arguments configured in the package.json
+ */
+function packageCfg() {
+  try {
+    return require(path.join(cwd, 'package.json'))['@pika/web'] || {};
+  } catch (e) {
+    return {};
+  }
+}
+
 export async function cli(args: string[]) {
-  const {help, optimize = false, strict = false, clean = false, dest = 'web_modules'} = yargs(args);
+  const {help, optimize = false, strict = false, clean = false, dest = 'web_modules'} = 
+    // overwrite package.json arguments with CLI arguments
+    Object.assign(packageCfg(), yargs(args));
   const destLoc = path.join(cwd, dest);
 
   if (help) {


### PR DESCRIPTION
- fixes #27
- CLI options take precedence over package.json options