### PR TITLE
Add basic import map support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,11 +166,13 @@ export async function install(
   }
 
   const depObject = {};
+  const importMap = {};
   for (const dep of arrayOfDeps) {
     try {
       const depName = getWebDependencyName(dep);
       const depLoc = resolveWebDependency(dep);
       depObject[depName] = depLoc;
+      importMap[depName] = `./${depName}.js`;
       detectionResults.push([dep, true]);
       spinner.text = banner + formatDetectionResults(skipFailures);
     } catch (err) {
@@ -187,7 +189,6 @@ export async function install(
       return false;
     }
   }
-
   if (Object.keys(depObject).length === 0) {
     logError(`No ESM dependencies found!`);
     console.log(chalk.dim(`  At least one dependency must have an ESM "module" entrypoint. You can find modern, web-ready packages at ${chalk.underline('https://www.pika.dev')}`));
@@ -262,6 +263,10 @@ export async function install(
   };
   const packageBundle = await rollup.rollup(inputOptions);
   await packageBundle.write(outputOptions);
+  fs.writeFileSync(
+    path.join(destLoc, 'import-map.json'),
+    JSON.stringify({imports: importMap}, undefined, 2), {encoding: 'utf8'}
+  );
   return true;
 }
 


### PR DESCRIPTION
/cc @matthewp @thepassel

Quick PR to add an automatically generated an import map for all installed deps. Would love any feedback since this is something I'm only just starting to experiment with.

## Example

Given this package.json config: 

```json
  "@pika/web": {
    "webDependencies": [
      "csz",
      "preact/hooks"
    ]
  },
```

@pika/web installs your dependencies with a new `import-map.json` file:
<img width="282" alt="Screen Shot 2019-07-15 at 3 01 47 PM" src="https://user-images.githubusercontent.com/622227/61252332-0c5a3880-a712-11e9-847b-1d8e79d362a7.png">

With the contents:
```json
{
  "imports": {
    "csz": "./csz.js",
    "preact/hooks": "./preact/hooks.js"
  }
}
```