### PR TITLE
Add basic glob support for assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1525,6 +1525,29 @@
         "p-map": "^2.0.0",
         "pify": "^4.0.1",
         "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "detect-indent": {
@@ -1713,27 +1736,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-    },
-    "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
     },
     "got": {
       "version": "9.6.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "^7.5.5",
     "@pika/cli": "latest",
     "chalk": "^2.4.2",
+    "glob": "^7.1.4",
     "is-builtin-module": "^3.0.0",
     "mkdirp": "^0.5.1",
     "ora": "^3.1.0",


### PR DESCRIPTION
This PR adds basic support for glob matching using explicit mode per the conversation in #85. This feature uses the [npm package, glob,](https://www.npmjs.com/package/glob)'s glob-matching syntax.

## Example

In package.json

```json
{
  "@pika/web": {
    "webDependencies": [
      "bootstrap/dist/css/*.css"
    ]
  }
}
```

Would yield the output

```
✔ @pika/web installed: bootstrap/dist
/css/bootstrap-grid.css, bootstrap/dist/css/bootstrap-grid.min.css, bootstrap/dist/css/bootstrap-reboot.css, bootstrap/dist/css/bootstrap-reboot.min.css, bootstrap/dist/css/bootstrap.css, bootstrap/dist/css/bootstrap.min.css. [1.59s]
```