### PR TITLE
Added `create-pika-app` node cli tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -13,7 +13,7 @@
 - PWA-Starter-Kit (lit-html + Redux): [[Source]](https://github.com/Polymer/pwa-starter-kit/issues/339)
 - LitElement + lit-html PWA: [[Source]](https://github.com/thepassle/reddit-pwa) [[Live Demo]](https://angry-turing-4769b3.netlify.com/)  
 - Terminal Homepage (Preact + Typescript + Babel): [[Source]](https://github.com/ndom91/terminal-homepage) [[Live Demo]](https://termy.netlify.com)  
-
+- create-pika-app (Bootstraping Tool): [[Source]](https://github.com/ndom91/create-pika-app)
 
 
 ## Call for Examples (CFE)


### PR DESCRIPTION
So I finished up a first release of the aforementioned `create-pika-app` cli tool I had mentioned previously. 

Its still a bit rough around the edges, but works well!

You can run it via `npx` directly, `cd` into the new directory, and immediately run `npm run dev`, for example, to see a live dev server of the included example project (a slimmed down version of the `terminal-homepage` example)

I'm not positive if 'Examples' is the correct spot for a cli not directly based on `@pika/web`, so please correct if wrong! 

This project itself uses `@pika/pack` and some builders to package up, but it generates a starter `@pika/web` based preact/typescript/babel project, so maybe it makes more sense as an example under `@pika/pkg`. Up to you guys!

Thanks for all the great work, I hope this can be of use to others!