### PR TITLE
Fix Preact

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -278,7 +278,7 @@ export async function install(
           },
         },
         rollupPluginNodeResolve({
-          mainFields: ['browser', 'module', !isStrict && 'main'].filter(Boolean),
+          mainFields: ['module', 'jsnext:main', 'browser', !isStrict && 'main'].filter(Boolean),
           modulesOnly: isStrict, // Default: false
           extensions: ['.mjs', '.cjs', '.js', '.json'], // Default: [ '.mjs', '.js', '.json', '.node' ]
           // whether to prefer built-in modules (e.g. `fs`, `path`) or local ones with the same names


### PR DESCRIPTION
So this is more of an open discussion, but I felt talking about an actual code change would be simpler than talking about this in abstract. Happy for pushback.

**Problem**
Preact build breaks due to the following sequence of events:
1. `preact-router` requires `preact`. Easy enough.
2. `preact-router` has `import { cloneElements } from 'preact'`. Still OK.
3. When `@pika/web` is resolving all these dependencies, it looks for `browser` before `module`. In Preact’s `package.json`, Rollup finds `"browser": "preact.umd.js"` and loads that. Yikes! No `export`s in there, and the build breaks:

```
Error: 'cloneElement' is not exported by node_modules/preact/dist/preact.umd.js
```

**Solution**
For Preact, `@pika/web` instead should have loaded `module` or `jsnext:main`, both of which are the ESM build of Preact. @pika/web builds fine using these.

--- 

Does this change make sense? Or does it introduce other problems?