### PR TITLE
added dedupe option to allow pika install with locally installed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Additionally, @pika/web runs all dependencies through Babel via `@preset/env` to
 
 * `"webDependencies"`: (Recommended) Configure which packages to install with @pika/web. Without this, @pika/web will just try to install every package in your "dependencies" config. That behavior is great for getting started but it won't warn you if an expected package fails to install. 
 * `"namedExports"`: (Optional) If needed, you can explicitly define named exports for any dependency. You should only use this if you're getting `"'X' is not exported by Y"` errors without it. See [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs#usage) for more info.
+* `"dedupe"`: (Optional) If needed, force resolving for these modules to root's node_modules. This helps prevend bundling package multiple time if package is imported from dependencies. See [rollup-plugin-node-resolve](https://github.com/rollup/rollup-plugin-node-resolve#usage). This is usefull when developing a dependency locally, and prevent rollup to duplicate dependencies included both in local and remote packages. 
 
 ```js
   "dependencies": { "htm": "^1.0.0", "preact": "^8.0.0", /* ... */ },
@@ -95,6 +96,10 @@ Additionally, @pika/web runs all dependencies through Babel via `@preset/env` to
       "unistore/full/preact.es.js", // An ESM file within a package (supports globs)
       "bulma/css/bulma.css" // A non-JS static asset (supports globs)
     ],
+    "dedupe": [
+        "lit-element",
+        "lit-html" 
+    ]
   },
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,7 +387,7 @@ export async function cli(args: string[]) {
   const {namedExports, webDependencies, dedupe} = pkgManifest['@pika/web'] || {
     namedExports: undefined,
     webDependencies: undefined,
-    dedupe: []
+    dedupe: undefined
   };
   const doesWhitelistExist = !!webDependencies;
   const arrayOfDeps = webDependencies || Object.keys(pkgManifest.dependencies || {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export interface InstallOptions {
   remoteUrl?: string;
   remotePackages: [string, string][];
   sourceMap?: boolean | 'inline';
+  dedupe?: string[]; 
 }
 
 const cwd = process.cwd();
@@ -173,6 +174,7 @@ export async function install(
     namedExports,
     remoteUrl,
     remotePackages,
+    dedupe
   }: InstallOptions,
 ) {
   const nodeModulesLoc = path.join(cwd, 'node_modules');
@@ -283,6 +285,7 @@ export async function install(
           extensions: ['.mjs', '.cjs', '.js', '.json'], // Default: [ '.mjs', '.js', '.json', '.node' ]
           // whether to prefer built-in modules (e.g. `fs`, `path`) or local ones with the same names
           preferBuiltins: false, // Default: true
+          dedupe: dedupe
         }),
         !isStrict &&
           rollupPluginJson({
@@ -381,9 +384,10 @@ export async function cli(args: string[]) {
   }
 
   const pkgManifest = require(path.join(cwd, 'package.json'));
-  const {namedExports, webDependencies} = pkgManifest['@pika/web'] || {
+  const {namedExports, webDependencies, dedupe} = pkgManifest['@pika/web'] || {
     namedExports: undefined,
     webDependencies: undefined,
+    dedupe: []
   };
   const doesWhitelistExist = !!webDependencies;
   const arrayOfDeps = webDependencies || Object.keys(pkgManifest.dependencies || {});
@@ -407,6 +411,7 @@ export async function cli(args: string[]) {
     remoteUrl,
     hasBrowserlistConfig,
     remotePackages: remotePackages.map(p => p.split(',')),
+    dedupe
   });
   if (result) {
     spinner.succeed(


### PR DESCRIPTION
added `dedupe` option to allow pika install with locally installed  package without duplicating dependencies in bundle.

As a follow-up of https://www.pika.dev/npm/@pika/web/discuss/23.

Not tested and I do not know ts...

It should hopefully allow to : 

```json
  "@pika/web": {
    "webDependencies": [ "your dependencies"],
    "dedupe": ["lit-element", "lit-html"]
```