### PR TITLE
Implement treeshaking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import rollupPluginJson from 'rollup-plugin-json';
 import rollupPluginBabel from 'rollup-plugin-babel';
 import {rollupPluginTreeshakeInputs} from './rollup-plugin-treeshake-inputs.js';
 import {rollupPluginRemoteResolve} from './rollup-plugin-remote-resolve.js';
-import {scanImports, scanWhitelist, InstallTarget} from './scan-imports.js';
+import {scanImports, scanDepList, InstallTarget} from './scan-imports.js';
 
 export interface DependencyLoc {
   type: 'JS' | 'ASSET';
@@ -154,10 +154,10 @@ function resolveWebDependency(dep: string, isExplicit: boolean): DependencyLoc {
 
 /**
  * Formats the @pika/web dependency name from a "webDependencies" input value:
- * 2. Remove any ".js" extension (will be added automatically by Rollup)
+ * 2. Remove any ".js"/".mjs" extension (will be added automatically by Rollup)
  */
 function getWebDependencyName(dep: string): string {
-  return dep.replace(/\.js$/, '');
+  return dep.replace(/\.m?js$/i, '');
 }
 
 export async function install(
@@ -376,14 +376,14 @@ export async function cli(args: string[]) {
 
   if (webDependencies) {
     isExplicit = true;
-    installTargets.push(...scanWhitelist(webDependencies, cwd));
+    installTargets.push(...scanDepList(webDependencies, cwd));
   }
   if (include) {
     isExplicit = true;
     installTargets.push(...scanImports(include, allDependencies));
   }
   if (!installTargets.length) {
-    installTargets.push(...scanWhitelist(implicitDependencies, cwd));
+    installTargets.push(...scanDepList(implicitDependencies, cwd));
   }
 
   const hasBrowserlistConfig =

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import glob from 'glob';
 import ora from 'ora';
 import yargs from 'yargs-parser';
 import resolveFrom from 'resolve-from';
+import babelPresetEnv from '@babel/preset-env';
+import isNodeBuiltin from 'is-builtin-module';
 
 import * as rollup from 'rollup';
 import rollupPluginNodeResolve from 'rollup-plugin-node-resolve';
@@ -15,14 +17,9 @@ import {terser as rollupPluginTerser} from 'rollup-plugin-terser';
 import rollupPluginReplace from 'rollup-plugin-replace';
 import rollupPluginJson from 'rollup-plugin-json';
 import rollupPluginBabel from 'rollup-plugin-babel';
-import babelPresetEnv from '@babel/preset-env';
-import isNodeBuiltin from 'is-builtin-module';
-import scanImports from './scan-imports.js';
-
-// Having trouble getting this ES2019 feature to compile, so using this ponyfill for now.
-function fromEntries(iterable: [string, string][]): {[key: string]: string} {
-  return [...iterable].reduce((obj, {0: key, 1: val}) => Object.assign(obj, {[key]: val}), {});
-}
+import {rollupPluginTreeshakeInputs} from './rollup-plugin-treeshake-inputs.js';
+import {rollupPluginRemoteResolve} from './rollup-plugin-remote-resolve.js';
+import {scanImports, scanWhitelist, InstallTarget} from './scan-imports.js';
 
 export interface DependencyLoc {
   type: 'JS' | 'ASSET';
@@ -47,7 +44,7 @@ export interface InstallOptions {
 
 const cwd = process.cwd();
 const banner = chalk.bold(`@pika/web`) + ` installing... `;
-const detectionResults = [];
+const installResults = [];
 let spinner = ora(banner);
 let spinnerHasError = false;
 
@@ -71,8 +68,8 @@ ${chalk.bold('Advanced:')}
   );
 }
 
-function formatDetectionResults(skipFailures): string {
-  return detectionResults
+function formatInstallResults(skipFailures): string {
+  return installResults
     .map(([d, yn]) => (yn ? chalk.green(d) : skipFailures ? chalk.dim(d) : chalk.red(d)))
     .join(', ');
 }
@@ -164,7 +161,7 @@ function getWebDependencyName(dep: string): string {
 }
 
 export async function install(
-  arrayOfDeps: string[],
+  installTargets: InstallTarget[],
   {
     isCleanInstall,
     destLoc,
@@ -180,55 +177,45 @@ export async function install(
     dedupe,
   }: InstallOptions,
 ) {
-  const nodeModulesLoc = path.join(cwd, 'node_modules');
   const knownNamedExports = {...namedExports};
-  const remotePackageMap = fromEntries(remotePackages);
-  const depList: Set<string> = new Set();
-  arrayOfDeps.forEach(dep => {
-    if (!glob.hasMagic(dep)) {
-      depList.add(dep);
-    } else {
-      glob.sync(dep, {cwd: nodeModulesLoc, nodir: true}).forEach(f => depList.add(f));
-    }
-  });
   for (const filePath of PACKAGES_TO_AUTO_DETECT_EXPORTS) {
     knownNamedExports[filePath] = knownNamedExports[filePath] || detectExports(filePath) || [];
   }
-
-  if (depList.size === 0) {
-    logError('no dependencies found.');
+  if (installTargets.length === 0) {
+    logError('Nothing to install.');
     return;
   }
   if (!fs.existsSync(path.join(cwd, 'node_modules'))) {
     logError('no "node_modules" directory exists. Did you run "npm install" first?');
     return;
   }
-
   if (isCleanInstall) {
     rimraf.sync(destLoc);
   }
 
-  const depObject: {[depName: string]: string} = {};
-  const assetObject: {[depName: string]: string} = {};
+  const allInstallSpecifiers = new Set(installTargets.map(dep => dep.specifier));
+  const depObject: {[targetName: string]: string} = {};
+  const assetObject: {[targetName: string]: string} = {};
   const importMap = {};
+  const installTargetsMap = {};
   const skipFailures = !isExplicit;
-  for (const dep of depList) {
+  for (const installSpecifier of allInstallSpecifiers) {
     try {
-      const depName = getWebDependencyName(dep);
-      const {type: depType, loc: depLoc} = resolveWebDependency(dep, isExplicit);
-      if (depType === 'JS') {
-        depObject[depName] = depLoc;
-        importMap[depName] = `./${depName}.js`;
-        detectionResults.push([dep, true]);
+      const targetName = getWebDependencyName(installSpecifier);
+      const {type: targetType, loc: targetLoc} = resolveWebDependency(installSpecifier, isExplicit);
+      if (targetType === 'JS') {
+        depObject[targetName] = targetLoc;
+        importMap[targetName] = `./${targetName}.js`;
+        installTargetsMap[targetLoc] = installTargets.filter(t => installSpecifier === t.specifier);
+        installResults.push([installSpecifier, true]);
+      } else if (targetType === 'ASSET') {
+        assetObject[targetName] = targetLoc;
+        installResults.push([installSpecifier, true]);
       }
-      if (depType === 'ASSET') {
-        assetObject[depName] = depLoc;
-        detectionResults.push([dep, true]);
-      }
-      spinner.text = banner + formatDetectionResults(skipFailures);
+      spinner.text = banner + formatInstallResults(skipFailures);
     } catch (err) {
-      detectionResults.push([dep, false]);
-      spinner.text = banner + formatDetectionResults(skipFailures);
+      installResults.push([installSpecifier, false]);
+      spinner.text = banner + formatInstallResults(skipFailures);
       if (skipFailures) {
         continue;
       }
@@ -261,27 +248,7 @@ export async function install(
           rollupPluginReplace({
             'process.env.NODE_ENV': isOptimized ? '"production"' : '"development"',
           }),
-        remotePackages.length > 0 && {
-          name: 'pika:peer-dependency-resolver',
-          resolveId(source: string) {
-            if (remotePackageMap[source]) {
-              let urlSourcePath = source;
-              // NOTE(@fks): This is really Pika CDN specific, but no one else should be using this option.
-              if (source === 'react' || source === 'react-dom') {
-                urlSourcePath = '_/' + source;
-              }
-              return {
-                id: `${remoteUrl}/${urlSourcePath}/${remotePackageMap[source]}`,
-                external: true,
-                isExternal: true,
-              };
-            }
-            return null;
-          },
-          load(id) {
-            return null;
-          },
-        },
+        remoteUrl && rollupPluginRemoteResolve({remoteUrl, remotePackages}),
         rollupPluginNodeResolve({
           mainFields: ['module', 'jsnext:main', 'browser', !isStrict && 'main'].filter(Boolean),
           modulesOnly: isStrict, // Default: false
@@ -314,6 +281,7 @@ export async function install(
               ],
             ],
           }),
+        !!isOptimized && rollupPluginTreeshakeInputs(installTargets),
         !!isOptimized && rollupPluginTerser(),
       ],
       onwarn: ((warning, warn) => {
@@ -388,25 +356,34 @@ export async function cli(args: string[]) {
   }
 
   const pkgManifest = require(path.join(cwd, 'package.json'));
+  const implicitDependencies = [
+    ...Object.keys(pkgManifest.dependencies || {}),
+    ...Object.keys(pkgManifest.peerDependencies || {}),
+  ];
+  const allDependencies = [
+    ...Object.keys(pkgManifest.dependencies || {}),
+    ...Object.keys(pkgManifest.peerDependencies || {}),
+    ...Object.keys(pkgManifest.devDependencies || {}),
+  ];
+
+  let isExplicit = false;
+  const installTargets = [];
   const {namedExports, webDependencies, dedupe} = pkgManifest['@pika/web'] || {
     namedExports: undefined,
     webDependencies: undefined,
     dedupe: undefined,
   };
 
-  let doesWhitelistExist = true;
-  const arrayOfDeps = [...webDependencies];
-  if (include) {
-    arrayOfDeps.push(
-      ...scanImports(include, {
-        dependencies: {...(pkgManifest.dependencies || {}), ...(pkgManifest.devDependencies || {})},
-        dest,
-      }),
-    );
+  if (webDependencies) {
+    isExplicit = true;
+    installTargets.push(...scanWhitelist(webDependencies, cwd));
   }
-  if (!arrayOfDeps.length) {
-    doesWhitelistExist = false;
-    arrayOfDeps.push(...Object.keys(pkgManifest.dependencies || {}));
+  if (include) {
+    isExplicit = true;
+    installTargets.push(...scanImports(include, allDependencies));
+  }
+  if (!installTargets.length) {
+    installTargets.push(...scanWhitelist(implicitDependencies, cwd));
   }
 
   const hasBrowserlistConfig =
@@ -417,11 +394,11 @@ export async function cli(args: string[]) {
 
   spinner.start();
   const startTime = Date.now();
-  const result = await install(arrayOfDeps, {
+  const result = await install(installTargets, {
     isCleanInstall: clean,
     destLoc,
     namedExports,
-    isExplicit: doesWhitelistExist,
+    isExplicit,
     isStrict: strict,
     isBabel: babel || optimize,
     isOptimized: optimize,
@@ -431,17 +408,19 @@ export async function cli(args: string[]) {
     remotePackages: remotePackages.map(p => p.split(',')),
     dedupe,
   });
+
   if (result) {
     spinner.succeed(
       chalk.bold(`@pika/web`) +
         ` installed: ` +
-        formatDetectionResults(!doesWhitelistExist) +
+        formatInstallResults(!isExplicit) +
         '. ' +
         chalk.dim(`[${((Date.now() - startTime) / 1000).toFixed(2)}s]`),
     );
   }
+
+  //If an error happened, set the exit code so that programmatic usage of the CLI knows.
   if (spinnerHasError) {
-    // Set the exit code so that programmatic usage of the CLI knows that there were errors.
     spinner.warn(chalk(`Finished with warnings.`));
     process.exitCode = 1;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,7 +382,7 @@ export async function cli(args: string[]) {
     isExplicit = true;
     installTargets.push(...scanImports(include, allDependencies));
   }
-  if (!installTargets.length) {
+  if (!webDependencies && !include) {
     installTargets.push(...scanDepList(implicitDependencies, cwd));
   }
 

--- a/src/rollup-plugin-remote-resolve.ts
+++ b/src/rollup-plugin-remote-resolve.ts
@@ -1,0 +1,36 @@
+/**
+ * rollup-plugin-remote-resolve
+ *
+ * Rewrites imports for "remote packages" to point to the remote URL instead.
+ * This shouldn't ever run by default, but must be activated via config.
+ */
+export function rollupPluginRemoteResolve({
+  remoteUrl,
+  remotePackages,
+}: {
+  remoteUrl: string;
+  remotePackages: [string, string][];
+}) {
+  const remotePackageMap = new Map(remotePackages);
+  return {
+    name: 'pika:peer-dependency-resolver',
+    resolveId(source: string) {
+      if (remotePackageMap.has(source)) {
+        let urlSourcePath = source;
+        // NOTE(@fks): This is really Pika CDN specific, but no one else should be using this option.
+        if (source === 'react' || source === 'react-dom') {
+          urlSourcePath = '_/' + source;
+        }
+        return {
+          id: `${remoteUrl}/${urlSourcePath}/${remotePackageMap.get(source)}`,
+          external: true,
+          isExternal: true,
+        };
+      }
+      return null;
+    },
+    load(id) {
+      return null;
+    },
+  };
+}

--- a/src/rollup-plugin-treeshake-inputs.ts
+++ b/src/rollup-plugin-treeshake-inputs.ts
@@ -51,8 +51,8 @@ export function rollupPluginTreeshakeInputs(allImports: InstallTarget[]) {
       const result = `
         ${treeshakeSummary.namespace ? `export * from '${fileLoc}';` : ''}
         ${
-          treeshakeSummary.default && !uniqueNamedImports.has('default')
-            ? `export {default} from '${fileLoc}';`
+          treeshakeSummary.default
+            ? `import __pika_web_default_export_for_treeshaking__ from '${fileLoc}'; export default __pika_web_default_export_for_treeshaking__;`
             : ''
         }
         ${`export {${[...uniqueNamedImports].join(',')}} from '${fileLoc}';`}

--- a/src/rollup-plugin-treeshake-inputs.ts
+++ b/src/rollup-plugin-treeshake-inputs.ts
@@ -1,0 +1,63 @@
+import {InputOptions} from 'rollup';
+import {InstallTarget} from './scan-imports';
+
+/**
+ * rollup-plugin-treeshake-inputs
+ *
+ * How it works:
+ * 1. An array of "install targets" are passed in, describing all known imports + metadata.
+ * 2. Known imports are marked for tree-shaking by appending 'pika-treeshake:' to the input value.
+ * 3. On load, we return a false virtual file for all "pika-treeshake:" inputs.
+ *    a. That virtual file contains only `export ... from 'ACTUAL_FILE_PATH';` exports
+ *    b. Rollup uses those exports to drive its tree-shaking algorithm.
+ */
+export function rollupPluginTreeshakeInputs(allImports: InstallTarget[]) {
+  const installTargetsByFile: {[loc: string]: InstallTarget[]} = {};
+  return {
+    name: 'pika:treeshake-inputs',
+    // Mark some inputs for tree-shaking.
+    options(inputOptions: InputOptions) {
+      for (const [key, val] of Object.entries(inputOptions.input)) {
+        installTargetsByFile[val] = allImports.filter(imp => imp.specifier === key);
+        // If an input has known install targets, and none of those have "all=true", mark for treeshaking.
+        if (
+          installTargetsByFile[val].length > 0 &&
+          !installTargetsByFile[val].some(imp => imp.all)
+        ) {
+          inputOptions.input[key] = `pika-treeshake:${val}`;
+        }
+      }
+      return inputOptions;
+    },
+    resolveId(source: string) {
+      if (source.startsWith('pika-treeshake:')) {
+        return source;
+      }
+      return null;
+    },
+    load(id: string) {
+      if (!id.startsWith('pika-treeshake:')) {
+        return null;
+      }
+      const fileLoc = id.substring('pika-treeshake:'.length);
+      // Reduce all install targets into a single "summarized" install target.
+      const treeshakeSummary = installTargetsByFile[fileLoc].reduce((summary, imp) => {
+        summary.default = summary.default || imp.default;
+        summary.namespace = summary.namespace || imp.namespace;
+        summary.named = [...summary.named, ...imp.named];
+        return summary;
+      });
+      const uniqueNamedImports = new Set(treeshakeSummary.named);
+      const result = `
+        ${treeshakeSummary.namespace ? `export * from '${fileLoc}';` : ''}
+        ${
+          treeshakeSummary.default && !uniqueNamedImports.has('default')
+            ? `export {default} from '${fileLoc}';`
+            : ''
+        }
+        ${`export {${[...uniqueNamedImports].join(',')}} from '${fileLoc}';`}
+      `;
+      return result;
+    },
+  };
+}

--- a/src/scan-imports.ts
+++ b/src/scan-imports.ts
@@ -18,8 +18,8 @@ export type InstallTarget = {
   named: string[];
 };
 
-function stripJsExtension(dep) {
-  return dep.replace(/\.js$/, '');
+function stripJsExtension(dep: string): string {
+  return dep.replace(/\.m?js$/i, '');
 }
 
 function createInstallTarget(specifier: string, all = true): InstallTarget {
@@ -105,17 +105,17 @@ function getInstallTargetsForFile(
   return allImports;
 }
 
-export function scanWhitelist(whitelist: string[], cwd: string): InstallTarget[] {
+export function scanDepList(depList: string[], cwd: string): InstallTarget[] {
   const nodeModulesLoc = nodePath.join(cwd, 'node_modules');
-  return whitelist
+  return depList
     .map(whitelistItem => {
       if (!glob.hasMagic(whitelistItem)) {
         return [createInstallTarget(whitelistItem, true)];
       } else {
-        return scanWhitelist(glob.sync(whitelistItem, {cwd: nodeModulesLoc, nodir: true}), cwd);
+        return scanDepList(glob.sync(whitelistItem, {cwd: nodeModulesLoc, nodir: true}), cwd);
       }
     })
-    .reduce((flat, item) => flat.concat(item));
+    .reduce((flat, item) => flat.concat(item), []);
 }
 
 export function scanImports(include: string, knownDependencies: string[]): InstallTarget[] {

--- a/src/scan-imports.ts
+++ b/src/scan-imports.ts
@@ -1,159 +1,131 @@
+import nodePath from 'path';
 import fs from 'fs';
-import chalk from 'chalk';
-import ora from 'ora';
 import glob from 'glob';
 import {parse} from '@babel/parser';
-import traverse, {NodePath} from '@babel/traverse';
-import {
-  CallExpression,
-  ImportDeclaration,
-  isImportDeclaration,
-  isCallExpression,
-} from '@babel/types';
+import traverse from '@babel/traverse';
 
 /**
- * Splits a filename into folder segments
+ * An install target represents information about a dependency to install.
+ * The specifier is the key pointing to the dependency, either as a package
+ * name or as an actual file path within node_modules. All other properties
+ * are metadata about what is actually being imported.
  */
-function explode(file: string) {
-  return file.split('/').filter(part => part);
+export type InstallTarget = {
+  specifier: string;
+  all: boolean;
+  default: boolean;
+  namespace: boolean;
+  named: string[];
+};
+
+function stripJsExtension(dep) {
+  return dep.replace(/\.js$/, '');
+}
+
+function createInstallTarget(specifier: string, all = true): InstallTarget {
+  return {
+    specifier,
+    all,
+    default: false,
+    namespace: false,
+    named: [],
+  };
 }
 
 /**
- * Attempt to figure out web_module’s identity
+ * parses an import specifier, looking for a web modules to install. If a web module is not detected,
+ * null is returned.
  */
-function resolveWebModule(name: string, dest: string) {
-  const lastSegment = [...explode(dest)].pop();
-  // is the last folder segment of --dest present?
-  if (name.includes(lastSegment)) {
-    const [_, webModule] = name.split(lastSegment);
-    if (webModule) {
-      return webModule.replace(/^\//, ''); // remove file extension, and leading slash, if any
-    }
+function parseWebModuleSpecifier(specifier: string, knownDependencies: string[]): null | string {
+  const webModulesIndex = specifier.indexOf('web_modules/');
+  if (webModulesIndex === -1) {
+    return null;
   }
-
-  // otherwise, return package name
-  return name;
+  // check if the resolved specifier (including file extension) is a known package.
+  const resolvedSpecifier = specifier.substring(webModulesIndex + 'web_modules/'.length);
+  if (knownDependencies.includes(resolvedSpecifier)) {
+    return resolvedSpecifier;
+  }
+  // check if the resolved specifier (without extension) is a known package.
+  const resolvedSpecifierWithoutExtension = stripJsExtension(resolvedSpecifier);
+  if (knownDependencies.includes(resolvedSpecifierWithoutExtension)) {
+    return resolvedSpecifierWithoutExtension;
+  }
+  // Otherwise, this is an explicit import to a file within a package.
+  return resolvedSpecifier;
 }
 
-/**
- * Return import name (or undefined)
- */
-function importModuleName(node: NodePath<ImportDeclaration>): string | undefined {
-  if (isImportDeclaration(node)) {
-    return node.node.source.value;
-  }
-  return undefined;
-}
-
-/**
- * Return dynamic import name (or undefined)
- */
-function dynamicImportModuleName(node: NodePath<CallExpression>): string | undefined {
-  if (isCallExpression(node)) {
-    if (node.node.callee.type === 'Import' && node.node.arguments && node.node.arguments.length) {
-      return (node.node.arguments[0] as any).value;
-    }
-  }
-  return undefined;
-}
-
-/**
- * Return array of dependencies
- */
-function parseImports(file: string) {
-  const code = fs.readFileSync(file, 'utf8');
-
-  // skip file if empty, or if permissions error
-  if (!code) {
-    return [];
-  }
-  const deps = new Set<string>();
-
-  // try to parse; this will fail if not JS
+function getInstallTargetsForFile(code: string, knownDependencies: string[]): InstallTarget[] {
+  const allImports: InstallTarget[] = [];
   try {
     const ast = parse(code, {plugins: ['dynamicImport'], sourceType: 'module'});
     traverse(ast, {
-      enter(node) {
-        const moduleName =
-          importModuleName(node as NodePath<ImportDeclaration>) ||
-          dynamicImportModuleName(node as NodePath<CallExpression>);
-
-        if (moduleName) {
-          deps.add(moduleName);
+      ImportDeclaration(path) {
+        const webModuleSpecifier = parseWebModuleSpecifier(
+          path.node.source.value,
+          knownDependencies,
+        );
+        if (webModuleSpecifier) {
+          allImports.push({
+            specifier: webModuleSpecifier,
+            all: false,
+            default: path.node.specifiers.some(s => s.type === 'ImportDefaultSpecifier'),
+            namespace: path.node.specifiers.some(s => s.type === 'ImportNamespaceSpecifier'),
+            named: path.node.specifiers
+              .map(s => s.type === 'ImportSpecifier' && s.imported.name)
+              .filter(Boolean),
+          });
+        }
+      },
+      Import(path) {
+        // Only match dynamic imports that are called as a function
+        if (path.parent.type !== 'CallExpression') {
+          return;
+        }
+        // Only match dynamic imports called with a single string argument
+        const [argNode] = path.parent.arguments;
+        if (argNode.type !== 'StringLiteral') {
+          return;
+        }
+        // Analyze that string argument as an import specifier
+        const webModuleSpecifier = parseWebModuleSpecifier(argNode.value, knownDependencies);
+        if (webModuleSpecifier) {
+          allImports.push(createInstallTarget(webModuleSpecifier, true));
         }
       },
     });
-    return [...deps];
   } catch (e) {
+    // TODO: report the error
     return [];
   }
+  return allImports;
 }
 
-interface ScanOptions {
-  dependencies: {[key: string]: string};
-  dest: string;
-}
-
-/**
- * Scan glob pattern for imports
- */
-export default function scanImports(include: string, options: ScanOptions): string[] {
-  if (!Object.keys(options.dependencies).length) {
-    console.warn(`No dependencies or devDependencies found in package.json`);
-    return [];
-  }
-
-  const files = glob.sync(include, {nodir: true});
-  if (!files.length) {
-    console.warn(`No files found matching ${include}`);
-    return [];
-  }
-
-  // start perf benchmark
-  const spinner = ora(`Scanning ${include}`).start();
-  const timeStart = process.hrtime();
-
-  // get all dependencies (even local ones)
-  const allDependencies = new Set<string>();
-  files.forEach(file => {
-    parseImports(file).forEach(dep => {
-      allDependencies.add(resolveWebModule(dep, options.dest));
-    });
-  });
-
-  // filter out modules not in options.dependencies and sort
-  const foundInDeps = (name: string) => !!options.dependencies[name];
-  const npmDependencies = [...allDependencies]
-    .map(originalName => {
-      // npm name (ex: `vue`)
-      if (foundInDeps(originalName)) {
-        return originalName;
+export function scanWhitelist(whitelist: string[], cwd: string): InstallTarget[] {
+  const nodeModulesLoc = nodePath.join(cwd, 'node_modules');
+  return whitelist
+    .map(whitelistItem => {
+      if (!glob.hasMagic(whitelistItem)) {
+        return [createInstallTarget(whitelistItem, true)];
+      } else {
+        return scanWhitelist(glob.sync(whitelistItem, {cwd: nodeModulesLoc, nodir: true}), cwd);
       }
-      // npm name + extension (ex: `graphql.js`)
-      const noExt = originalName.replace(/\.[^.]+$/, '');
-      if (foundInDeps(noExt)) {
-        return noExt;
-      }
-      // nested dep (ex: `algoliasearch/dist/algoliasearchLite.js`)
-      const [scope, name] = explode(originalName);
-      const rootName = scope.startsWith('@') ? `${scope}/${name}` : scope;
-      if (foundInDeps(rootName)) {
-        return originalName;
-      }
-      // dep not found
-      return undefined;
     })
-    .filter(dep => dep) // filter out unresolved
-    .sort((a, b) => a.localeCompare(b));
+    .reduce((flat, item) => flat.concat(item));
+}
 
-  // end perf benchmark & print
-  const timeEnd = process.hrtime(timeStart);
-  const ms = timeEnd[0] + Math.round(timeEnd[1] / 1e6);
-  spinner.succeed(
-    `@pika/web resolved: ${npmDependencies.length} dependencies ${chalk.dim(
-      `[${ms.toString()}ms]`,
-    )}`,
-  );
+export function scanImports(include: string, knownDependencies: string[]): InstallTarget[] {
+  const includeFiles = glob.sync(include, {nodir: true});
+  if (!includeFiles.length) {
+    console.warn(`Warning: No files matching "${include}"`);
+    return [];
+  }
 
-  return npmDependencies;
+  // Scan every matched JS file for web dependency imports
+  return includeFiles
+    .filter(file => file.endsWith('.js') || file.endsWith('mjs'))
+    .map(file => fs.readFileSync(file, 'utf8'))
+    .map(code => getInstallTargetsForFile(code, knownDependencies))
+    .reduce((flat, item) => flat.concat(item))
+    .sort((impA, impB) => impA.specifier.localeCompare(impB.specifier));
 }


### PR DESCRIPTION
This PR implements tree-shaking for dependencies, built on top of the work done in #105 for scanning of imports. The biggest change to the plumbing was that we now need to track metadata about dependencies (ex: what is imported off of them) in addition to the single string identifier we were using. This introduces a new "InstallTarget" object to represent this new data structure. The output of the "scanning" phase is an array of InstallTargets, and is then passed as the main input to the "install" phase. 

This feature is currently only enabled when the `--include` flag is used (to enable import scanning) ***with*** the `--optimize` flag. This is intentional: tree-shaking dependencies turn @pika/web from an install-time tool to a build-time too, since changing your source code to add a new import would need @pika/web to re-run. It should only be done when building for production.

I'm really, *really* excited about this work, this is a huge win for the @pika/web perf story.