### PR TITLE
Lint with Prettier

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,12 @@
+name: Pull Request
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+      - run: npm install
+      - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "format": "prettier --write \"src/**/*.ts\"",
     "build": "pika build",
+    "lint": "prettier --check 'src/**/*.ts'",
     "publish": "pika publish",
     "version": "npm run build",
     "test": "jest __tests__/runner.js"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "scripts": {
-    "format": "prettier --write \"src/**/*.ts\"",
     "build": "pika build",
+    "format": "prettier --write 'src/**/*.ts'",
     "lint": "prettier --check 'src/**/*.ts'",
     "publish": "pika publish",
     "version": "npm run build",


### PR DESCRIPTION
Adds a GitHub Action + command to lint only using Prettier. Will fail if Prettier needs to be run before merging a branch.

Open to feedback! If this looks good, maybe we could enable something similar on pikapkg/pack.